### PR TITLE
Bill inference to a Team/Enterprise organization (X-HF-Bill-To)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ Each model entry also offers `cheapest` and `fastest` mode for each model. `fast
 * VS Code 1.104.0 or higher.
 * Hugging Face access token with `inference.serverless` permissions.
 
+## 🏢 Billing to a Team or Enterprise organization
+
+[Team and Enterprise organizations](https://huggingface.co/enterprise) can centralize Inference Providers billing: every member keeps using their own access token, but the requests are charged to the organization instead of the individual account.
+
+Enable it from the extension:
+1. Open the chat model picker → **Manage Models…** → **Hugging Face**.
+2. Choose **Bill to an Organization** and enter your organization name (e.g. `my-org`).
+
+Or set it directly in your VS Code settings:
+```jsonc
+// settings.json
+"huggingface.billTo": "my-org"
+```
+
+The extension forwards this value as the `X-HF-Bill-To` header on inference requests.
+
+**Resource groups.** Enterprise organizations with [Resource Groups](https://huggingface.co/docs/hub/security-resource-groups) can attribute inference costs to a specific group by entering the **resource group ID** instead of the organization name. Your token must be a member of that resource group.
+
+> ℹ️ Your access token must belong to the organization. Usage is tracked on the organization's billing page, where admins can set a spending limit and disable specific providers. Team & Enterprise organizations also receive a pool of free monthly credits based on the number of seats.
+
 ## 🛠️ Development
 ```bash
 git clone https://github.com/huggingface/huggingface-vscode-chat

--- a/package.json
+++ b/package.json
@@ -50,7 +50,18 @@
 				"command": "huggingface.manage",
 				"title": "Manage Hugging Face Provider"
 			}
-		]
+		],
+		"configuration": {
+			"title": "Hugging Face",
+			"properties": {
+				"huggingface.billTo": {
+					"type": "string",
+					"default": "",
+					"markdownDescription": "Bill Hugging Face Inference Providers usage to a Team or Enterprise organization instead of your personal account. Enter your **organization name** (e.g. `my-org`), or an Enterprise **resource group ID** to attribute costs to a specific resource group. You still authenticate with your own access token, which must be a member of the organization (or resource group). Sent as the `X-HF-Bill-To` header on inference requests. [Learn more](https://huggingface.co/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations).",
+					"scope": "machine-overridable"
+				}
+			}
+		}
 	},
 	"main": "./out/extension.js",
 	"scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,28 +13,102 @@ export function activate(context: vscode.ExtensionContext) {
 	// Register the Hugging Face provider under the vendor id used in package.json
 	vscode.lm.registerLanguageModelChatProvider("huggingface", provider);
 
-	// Management command to configure API key
+	// Management command: configure the API key and optional organization billing.
 	context.subscriptions.push(
 		vscode.commands.registerCommand("huggingface.manage", async () => {
-			const existing = await context.secrets.get("huggingface.apiKey");
-			const apiKey = await vscode.window.showInputBox({
-				title: "Hugging Face API Key",
-				prompt: existing ? "Update your Hugging Face API key" : "Enter your Hugging Face API key",
-				ignoreFocusOut: true,
-				password: true,
-				value: existing ?? "",
-			});
-			if (apiKey === undefined) {
-				return; // user canceled
-			}
-			if (!apiKey.trim()) {
-				await context.secrets.delete("huggingface.apiKey");
-				vscode.window.showInformationMessage("Hugging Face API key cleared.");
-				return;
-			}
-			await context.secrets.store("huggingface.apiKey", apiKey.trim());
-			vscode.window.showInformationMessage("Hugging Face API key saved.");
+			await manageProvider(context);
 		})
+	);
+}
+
+/** Present a small menu to manage the token and organization billing target. */
+async function manageProvider(context: vscode.ExtensionContext): Promise<void> {
+	const config = vscode.workspace.getConfiguration("huggingface");
+	const hasKey = !!(await context.secrets.get("huggingface.apiKey"));
+	const billTo = (config.get<string>("billTo") ?? "").trim();
+
+	type ManageAction = "setToken" | "setBillTo" | "clearBillTo";
+	const items: (vscode.QuickPickItem & { action: ManageAction })[] = [
+		{
+			label: "$(key) Set Hugging Face Token",
+			description: hasKey ? "Update or clear your saved token" : "Not set",
+			action: "setToken",
+		},
+		{
+			label: "$(organization) Bill to an Organization",
+			description: billTo ? `Currently billing to "${billTo}"` : "Off — usage billed to your account",
+			detail: "Charge inference usage to a Team/Enterprise organization or resource group (X-HF-Bill-To)",
+			action: "setBillTo",
+		},
+	];
+	if (billTo) {
+		items.push({
+			label: "$(clear-all) Stop Billing to Organization",
+			description: "Bill usage to your personal account",
+			action: "clearBillTo",
+		});
+	}
+
+	const pick = await vscode.window.showQuickPick(items, {
+		title: "Manage Hugging Face Provider",
+		placeHolder: "Configure your Hugging Face token and billing",
+	});
+	if (!pick) {
+		return; // user dismissed the menu
+	}
+
+	switch (pick.action) {
+		case "setToken":
+			await setToken(context);
+			break;
+		case "setBillTo":
+			await setBillTo(config, billTo);
+			break;
+		case "clearBillTo":
+			await config.update("billTo", "", vscode.ConfigurationTarget.Global);
+			vscode.window.showInformationMessage("Hugging Face inference is now billed to your personal account.");
+			break;
+	}
+}
+
+async function setToken(context: vscode.ExtensionContext): Promise<void> {
+	const existing = await context.secrets.get("huggingface.apiKey");
+	const apiKey = await vscode.window.showInputBox({
+		title: "Hugging Face API Key",
+		prompt: existing ? "Update your Hugging Face API key (leave empty to clear)" : "Enter your Hugging Face API key",
+		ignoreFocusOut: true,
+		password: true,
+		value: existing ?? "",
+	});
+	if (apiKey === undefined) {
+		return; // user canceled
+	}
+	if (!apiKey.trim()) {
+		await context.secrets.delete("huggingface.apiKey");
+		vscode.window.showInformationMessage("Hugging Face API key cleared.");
+		return;
+	}
+	await context.secrets.store("huggingface.apiKey", apiKey.trim());
+	vscode.window.showInformationMessage("Hugging Face API key saved.");
+}
+
+async function setBillTo(config: vscode.WorkspaceConfiguration, existing: string): Promise<void> {
+	const billTo = await vscode.window.showInputBox({
+		title: "Bill to a Hugging Face Organization",
+		prompt: "Organization name or Enterprise resource group ID to bill inference usage to. Leave empty to bill your personal account.",
+		placeHolder: "my-org  •  or a resource group ID",
+		ignoreFocusOut: true,
+		value: existing,
+	});
+	if (billTo === undefined) {
+		return; // user canceled
+	}
+	const trimmed = billTo.trim();
+	await config.update("billTo", trimmed, vscode.ConfigurationTarget.Global);
+	vscode.window.showInformationMessage(
+		trimmed
+			? `Hugging Face inference will be billed to "${trimmed}".`
+			: "Hugging Face inference is now billed to your personal account."
 	);
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -81,6 +81,17 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	}
 
 	/**
+	 * Organization (or Enterprise resource group) that inference usage should be billed to.
+	 * Read from the `huggingface.billTo` setting; forwarded as the `X-HF-Bill-To` header.
+	 * Returns `undefined` when unset so requests fall back to the token owner's account.
+	 */
+	private getBillTo(): string | undefined {
+		const billTo = vscode.workspace.getConfiguration("huggingface").get<string>("billTo");
+		const trimmed = billTo?.trim();
+		return trimmed ? trimmed : undefined;
+	}
+
+	/**
 	 * Get the list of available language models contributed by this provider
 	 * @param options Options which specify the calling context of this function
 	 * @param token A cancellation token which signals if the user cancelled the request or not
@@ -327,13 +338,19 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			if (toolConfig.tool_choice) {
 				(requestBody as Record<string, unknown>).tool_choice = toolConfig.tool_choice;
 			}
+			const headers: Record<string, string> = {
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+				"User-Agent": this.userAgent,
+			};
+			// Centralize billing to a Team/Enterprise organization (or resource group) when configured.
+			const billTo = this.getBillTo();
+			if (billTo) {
+				headers["X-HF-Bill-To"] = billTo;
+			}
 			const response = await fetch(`${BASE_URL}/chat/completions`, {
                 method: "POST",
-                headers: {
-                    Authorization: `Bearer ${apiKey}`,
-                    "Content-Type": "application/json",
-					"User-Agent": this.userAgent,
-                },
+                headers,
                 body: JSON.stringify(requestBody),
             });
 


### PR DESCRIPTION
## What & why

Closes #14 — _"How to set it to bill by org instead of my account?"_

Team & Enterprise organizations can [centralize Inference Providers billing](https://huggingface.co/docs/inference-providers/pricing#billing-for-team-and-enterprise-organizations): each member keeps using their own access token, but requests are charged to the organization by sending an `X-HF-Bill-To` header. This PR wires that into the extension.

## Changes

- **`src/provider.ts`** — read the new `huggingface.billTo` setting and attach `X-HF-Bill-To` to `/chat/completions` requests when set. When empty, requests fall back to the token owner's account (current behavior). Applied to inference only — model listing isn't billed, so no header is sent there (also avoids resource-group membership 403s on a non-billable call).
- **`src/extension.ts`** — the `huggingface.manage` command now opens a **QuickPick menu** instead of a single forced prompt: set/clear the token, set the billing org/resource group, or switch billing back to your personal account. The menu shows the current billing target at a glance.
- **`package.json`** — contribute `huggingface.billTo` so it's also editable from the native VS Code Settings UI and overridable per workspace.
- **`README.md`** — document organization billing and Enterprise resource groups.

## Resource groups

The setting accepts either an **organization name** (`my-org`) or an Enterprise **resource group ID** — both are forwarded verbatim as `X-HF-Bill-To`, matching the API. The token must be a member of the org/resource group.

## How this improves on #11

- **Focused diff** — no unrelated `fetch`/`TextDecoder`/logging wrapper refactor; keeps the runtime surface untouched.
- **Better UX** — a management menu that surfaces the current billing target and lets you change billing without re-entering your token, rather than a linear prompt chain that fires on every key edit.
- **Fuller coverage** — first-class support and docs for Enterprise **resource group IDs**, not just org names.
- **Discoverable** — the setting shows up in the VS Code Settings UI with a documented description and a link to the pricing docs, and can be overridden per workspace.

## Testing

- `npx tsc -p ./ --noEmit` — no errors in `provider.ts`/`extension.ts` (pre-existing unrelated errors in untracked WIP files only).
- Manual: header present with `huggingface.billTo` set, absent when empty; QuickPick set/clear flows update the setting and status messages accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWfrgnoQFTLXLSLXfE1bJr